### PR TITLE
redirect problem fixed

### DIFF
--- a/src/main/java/org/apache/jmeter/protocol/ssh/sampler/SSHCommandSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/ssh/sampler/SSHCommandSampler.java
@@ -143,6 +143,13 @@ public class SSHCommandSampler extends AbstractSSHSampler {
             }
         }
         
+        while (true) {
+            if (channel.isClosed()) {
+                break;
+            }
+            try {Thread.sleep(100);} catch (Exception ee){};
+        }
+
         if(useReturnCode){
             res.setResponseCode(String.valueOf(channel.getExitStatus()));
         }else{


### PR DESCRIPTION
The current code cannot handle the commands which use redirection. In these commands, close of the InputStream does not mean the completion of the command, and we need to wait the completion of the command. Please refer to the JSch's example: http://www.jcraft.com/jsch/examples/Exec.java.html .