### PR TITLE
set publickey, password as preferred authentication option over gssap…

### DIFF
--- a/src/main/java/org/apache/jmeter/protocol/ssh/sampler/AbstractSSHSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/ssh/sampler/AbstractSSHSampler.java
@@ -69,6 +69,7 @@ public abstract class AbstractSSHSampler extends AbstractSampler implements Test
                 jsch.addIdentity(getSshkeyfile());
             }
             session.setConfig("StrictHostKeyChecking", "no");
+            session.setConfig("PreferredAuthentications", "publickey,keyboard-interactive,password");
             session.connect(connectionTimeout);
         } catch (JSchException e) {
             failureReason = e.getMessage();


### PR DESCRIPTION
This avoids Kerberos prompts in certain machines as mentioned in #14 