### PR TITLE
travis CI: remove oraclejdk7 add openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
   - openjdk7
-  - oraclejdk7
+  - openjdk8
   - oraclejdk8


### PR DESCRIPTION
[Oracle JDK 7 is not supported in recent travis images](https://github.com/travis-ci/travis-ci/issues/7964#issuecomment-316769421) which is causing your builds to fail. removed oraclejdk7, added openjdk8 instead.

also please consider releasing 1.1.2 
Thanks